### PR TITLE
Create HRS document gallery shortcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,9 +36,13 @@ This document details all notable changes to the WSU HRS Child Theme. Uses [Sema
 
 ### Todo
 
-- Create HRS document gallery shortcode (copy from helper plugin).
 - Create HRS last updated shortcode (copy from helper plugin).
 - Redirect users to homepage on logout (copy from helper plugin).
+
+### Added
+
+- Namespace the HRS document gallery shortcode.
+- HRS document gallery shortcode that largely duplicates the standard WP gallery shortcode, but for PDF thumbnail galleries.
 
 ## 0.12.0 (2018-06-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ This document details all notable changes to the WSU HRS Child Theme. Uses [Sema
 - Get Babel processing working, open #35.
 - Determine if we really need the `center-middle` utility class. If yes, look into using a flex or grid with `Xvh` and `Xvh` column and row size to center instead.
 
+## 0.13.0 (unreleased)
+
+### Todo
+
+- Create HRS document gallery shortcode (copy from helper plugin).
+- Create HRS last updated shortcode (copy from helper plugin).
+- Redirect users to homepage on logout (copy from helper plugin).
+
 ## 0.12.0 (2018-06-08)
 
 ### Changed

--- a/functions.php
+++ b/functions.php
@@ -5,7 +5,7 @@
  *
  * @since 0.7.0
  */
-$hrs_child_theme_version = '0.12.0';
+$hrs_child_theme_version = '0.13.0~alpha1';
 
 /**
  * Sets up basic theme configuration and WordPress API settings.

--- a/includes/class-hrs-theme-setup.php
+++ b/includes/class-hrs-theme-setup.php
@@ -63,9 +63,9 @@ class HRS_Theme_Setup {
 	}
 
 	/**
-	 * Includes the required files.
+	 * Includes files required by the HRS theme.
 	 *
-	 * @since 0.1.0
+	 * @since 0.13.0
 	 *
 	 * @access private
 	 */

--- a/includes/class-hrs-theme-setup.php
+++ b/includes/class-hrs-theme-setup.php
@@ -30,6 +30,7 @@ class HRS_Theme_Setup {
 		if ( null === $instance ) {
 			$instance = new HRS_Theme_Setup();
 			$instance->setup_hooks();
+			$instance->includes();
 		}
 
 		return $instance;
@@ -59,6 +60,18 @@ class HRS_Theme_Setup {
 		add_action( 'after_setup_theme', array( $this, 'get_hrs_spine_schema' ), 5 );
 		add_filter( 'spine_get_title', array( $this, 'hrs_get_page_title' ) );
 		add_filter( 'spine_enable_builder_module', '__return_true' );
+	}
+
+	/**
+	 * Includes the required files.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @access private
+	 */
+	private function includes() {
+		// The HRS documents gallery shortcode.
+		require __DIR__ . '/shortcode-document-gallery.php';
 	}
 
 	/**

--- a/includes/shortcode-document-gallery.php
+++ b/includes/shortcode-document-gallery.php
@@ -6,11 +6,11 @@
  * @since 0.13.0
  */
 
+namespace WSU\HRS\Shortcode_Documents_Gallery;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
-namespace WSU\HRS\Shortcode_Documents_Gallery;
 
 add_shortcode( 'hrsgallery', 'WSU\HRS\Shortcode_Documents_Gallery\hrs_gallery' );
 

--- a/includes/shortcode-document-gallery.php
+++ b/includes/shortcode-document-gallery.php
@@ -10,19 +10,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-add_shortcode( 'hrsgallery', 'hrs_gallery' );
+namespace WSU\HRS\Shortcode_Documents_Gallery;
+
+add_shortcode( 'hrsgallery', 'WSU\HRS\Shortcode_Documents_Gallery\hrs_gallery' );
 
 /**
- * Builds the HRS Gallery shortcode output.
+ * Builds the HRS Documents Gallery shortcode output.
  *
  * Mostly just a slimmed-down and adjusted duplicate of the WP Gallery
  * shortcode {@see gallery_shortcode}. This version includes PDF docs
  * in its output, allowing users to create a "gallery" of PDF documents
  * and/or images represented either by thumbnails (if capable) or icons.
  *
- * @since 1.1.0
- *
- * @staticvar int $instance
+ * @since 0.13.0
  *
  * @param array $attr {
  *     Attributes of the HRS gallery shortcode
@@ -49,7 +49,7 @@ add_shortcode( 'hrsgallery', 'hrs_gallery' );
  * }
  * @return string HTML content to display a gallery.
  */
-public function hrs_gallery( $attr ) {
+function hrs_gallery( $attr ) {
 	$post = get_post();
 
 	static $instance = 0;

--- a/includes/shortcode-document-gallery.php
+++ b/includes/shortcode-document-gallery.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * HRS Child Theme Documents Gallery: Shortcode
+ *
+ * @package WSU_Human_Resources_Services
+ * @since 0.13.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+add_shortcode( 'hrsgallery', 'hrs_gallery' );
+
+/**
+ * Builds the HRS Gallery shortcode output.
+ *
+ * Mostly just a slimmed-down and adjusted duplicate of the WP Gallery
+ * shortcode {@see gallery_shortcode}. This version includes PDF docs
+ * in its output, allowing users to create a "gallery" of PDF documents
+ * and/or images represented either by thumbnails (if capable) or icons.
+ *
+ * @since 1.1.0
+ *
+ * @staticvar int $instance
+ *
+ * @param array $attr {
+ *     Attributes of the HRS gallery shortcode
+ *
+ *     @type string $order      Order of the images in the gallery. Default 'ASC'. Accepts 'ASC', 'DESC'.
+ *     @type string $orderby    The field to use when ordering images. Default 'menu_order ID'.
+ *                              Accepts any valid SQL ORDERBY statement.
+ *     @type int $id            A Post ID used to get default attachments.
+ *     @type string $itemtag    HTML tag to use for each image in the gallery. Default 'dl',
+ *                              or 'figure' if the theme registered support for HTML5.
+ *     @type string $icontag    HTML tag to use for each image's icon. Default 'dt', of 'div'
+ *                              if the theme registered support for HTML5.
+ *     @type string $captiontag HTML tag to use for each image's caption. Default 'dd', or 'figcaption'
+ *                              if the theme registered support for HTML5.
+ *     @type int $columns       Number of columns of images to display. Default 3.
+ *     @type string|array $size Size of the images to display. Accepts any valid size, or an array of
+ *                              width and height values (in that order) in pixels. Default 'thumbnail'.
+ *     @type string $ids        A comma-separated list of IDs of attachments to display. Default empty.
+ *     @type string $urls       A comma-separated list of URLs of attachments to display. Default empty.
+ *     @type string $include    A comma-separated list of IDs of attachments to include. Default empty.
+ *     @type string $exclude    A comma-separated list of IDs of attachments to exclude. Default empty.
+ *     @type string $link       What to link each image to. Default empty (links to the attachment page.)
+ *                              Accepts 'file' or 'none'.
+ * }
+ * @return string HTML content to display a gallery.
+ */
+public function hrs_gallery( $attr ) {
+	$post = get_post();
+
+	static $instance = 0;
+	$instance++;
+
+	// Build the includes array if the user specified IDs.
+	if ( ! empty( $attr['ids'] ) || ! empty( $attr['urls'] ) ) {
+		$attr['include'] = '';
+		// Order 'ids' by `post__in` unless otherwise specified.
+		if ( empty( $attr['orderby'] ) ) {
+			$attr['orderby'] = 'post__in';
+		}
+		// If given comma-separated URLs, try to get the attachment IDs.
+		if ( ! empty( $attr['urls'] ) ) {
+			$_urls = explode( ',', $attr['urls'] );
+			foreach ( $_urls as $url ) {
+				 $att_id = attachment_url_to_postid( esc_url( $url ) );
+				 $attr['include'] .= $att_id ? $att_id . ',' : '';
+			}
+		}
+		$attr['include'] .= $attr['ids'];
+	}
+
+	// Check for <figure> element support.
+	$html5 = current_theme_supports( 'html5', 'gallery' );
+	$atts = shortcode_atts( array(
+		'order'      => 'ASC',
+		'orderby'    => 'menu_order ID',
+		'id'         => $post ? $post->ID : 0,
+		'itemtag'    => $html5 ? 'figure' : 'dl',
+		'icontag'    => $html5 ? 'div' : 'dt',
+		'captiontag' => $html5 ? 'figcaption' : 'dd',
+		'columns'    => 3,
+		'size'       => 'thumbnail',
+		'useicon'     => false,
+		'include'    => '',
+		'exclude'    => '',
+		'link'       => 'file',
+	), $attr, 'hrsthumb' );
+
+	$id = intval( $atts['id'] );
+
+	// Retrieve the attachments.
+	if ( ! empty( $atts['include'] ) ) {
+		$_attachments = get_posts( array(
+			'include' => $atts['include'],
+			'post_status' => 'inherit',
+			'post_type' => 'attachment',
+			'post_mime_type' => 'image,application/pdf',
+			'order' => $atts['order'],
+			'orderby' => $atts['orderby'],
+		) );
+
+		$attachments = array();
+		foreach ( $_attachments as $key => $val ) {
+			$attachments[ $val->ID ] = $_attachments[ $key ];
+		}
+	} elseif ( ! empty( $atts['exclude'] ) ) {
+		// Uses get_children to use linked attachments as the includes.
+		$attachments = get_children( array(
+			'post_parent' => $id,
+			'exclude' => $atts['exclude'],
+			'post_status' => 'inherit',
+			'post_type' => 'attachment',
+			'post_mime_type' => 'image,application/pdf',
+			'order' => $atts['order'],
+			'orderby' => $atts['orderby'],
+		) );
+	} else {
+		// If no attachments are specified, default to those attached to the current post.
+		$attachments = get_children( array(
+			'post_parent' => $id,
+			'post_status' => 'inherit',
+			'post_type' => 'attachment',
+			'post_mime_type' => 'image,application/pdf',
+			'order' => $atts['order'],
+			'orderby' => $atts['orderby'],
+		) );
+	}
+
+	if ( empty( $attachments ) ) {
+		return '';
+	}
+
+	if ( is_feed() ) {
+		$output = "\n";
+		foreach ( $attachments as $att_id => $attachment ) {
+			$output .= wp_get_attachment_link( $att_id, $atts['size'], true ) . "\n";
+		}
+		return $output;
+	}
+
+	// Build elements.
+	$itemtag = tag_escape( $atts['itemtag'] );
+	$captiontag = tag_escape( $atts['captiontag'] );
+	$icontag = tag_escape( $atts['icontag'] );
+	$valid_tags = wp_kses_allowed_html( 'post' );
+
+	if ( ! isset( $valid_tags[ $itemtag ] ) ) {
+		$itemtag = 'dd';
+	}
+	if ( ! isset( $valid_tags[ $captiontag ] ) ) {
+		$captiontag = 'dd';
+	}
+	if ( ! isset( $valid_tags[ $icontag ] ) ) {
+		$icontag = 'dt';
+	}
+
+	$columns = intval( $atts['columns'] );
+	$selector = "hrs-gallery-{$instance}";
+	$size_class = sanitize_html_class( $atts['size'] );
+
+	$output = "<div id='{$selector}' class='gallery hrs-gallery gallery-{$id} gallery-columns-{$columns} gallery-size-{$size_class}'>";
+
+	$i = 0;
+	foreach ( $attachments as $id => $attachment ) {
+		$attr = ( trim( $attachment->post_excerpt ) ) ? array(
+			'aria-describedby' => "selector-$id",
+		) : '';
+		if ( ! empty( $atts['link'] ) && 'file' === $atts['link'] ) {
+			$image_output = wp_get_attachment_link( $id, $atts['size'], false, $atts['useicon'], false, $attr );
+		} elseif ( ! empty( $atts['link'] ) && 'none' === $atts['link'] ) {
+			$image_output = wp_get_attachment_link( $id, $atts['size'], false, $attr );
+		} else {
+			$image_output = wp_get_attachment_link( $id, $atts['size'], true, $atts['useicon'], false, $attr );
+		}
+		$image_meta = wp_get_attachment_metadata( $id );
+
+		$orientation = '';
+		if ( isset( $image_meta['height'], $image_meta['width'] ) ) {
+			$orientation = ( $image_meta['height'] > $image_meta['width'] ) ? 'portrait' : 'landscape';
+		}
+		$output .= "<{$itemtag} class='gallery-item'>";
+		$output .= "
+				<{$icontag} class='gallery-icon {$orientation}'>
+					{$image_output}
+				</{$icontag}>";
+		if ( $captiontag && trim( $attachment->post_excerpt ) ) {
+			$output .= "
+					<{$captiontag} class='wp-caption-text gallery-caption' id='{$selector}-{$id}'>
+					" . wptexturize( $attachment->post_excerpt ) . "
+					</{$captiontag}>";
+		}
+		$output .= "</{$itemtag}>";
+		if ( ! $html5 && $columns > 0 && 0 === ( $i + 1 ) % $columns ) {
+			$output .= '<br style="clear: both" />';
+		}
+	}
+
+	$output .= "
+			</div>\n";
+
+	return $output;
+}

--- a/includes/shortcode-document-gallery.php
+++ b/includes/shortcode-document-gallery.php
@@ -66,8 +66,8 @@ function hrs_gallery( $attr ) {
 		if ( ! empty( $attr['urls'] ) ) {
 			$_urls = explode( ',', $attr['urls'] );
 			foreach ( $_urls as $url ) {
-				 $att_id = attachment_url_to_postid( esc_url( $url ) );
-				 $attr['include'] .= $att_id ? $att_id . ',' : '';
+				$att_id           = attachment_url_to_postid( esc_url( $url ) );
+				$attr['include'] .= $att_id ? $att_id . ',' : '';
 			}
 		}
 		$attr['include'] .= $attr['ids'];
@@ -75,7 +75,7 @@ function hrs_gallery( $attr ) {
 
 	// Check for <figure> element support.
 	$html5 = current_theme_supports( 'html5', 'gallery' );
-	$atts = shortcode_atts( array(
+	$atts  = shortcode_atts( array(
 		'order'      => 'ASC',
 		'orderby'    => 'menu_order ID',
 		'id'         => $post ? $post->ID : 0,
@@ -84,7 +84,7 @@ function hrs_gallery( $attr ) {
 		'captiontag' => $html5 ? 'figcaption' : 'dd',
 		'columns'    => 3,
 		'size'       => 'thumbnail',
-		'useicon'     => false,
+		'useicon'    => false,
 		'include'    => '',
 		'exclude'    => '',
 		'link'       => 'file',
@@ -95,12 +95,12 @@ function hrs_gallery( $attr ) {
 	// Retrieve the attachments.
 	if ( ! empty( $atts['include'] ) ) {
 		$_attachments = get_posts( array(
-			'include' => $atts['include'],
-			'post_status' => 'inherit',
-			'post_type' => 'attachment',
+			'include'        => $atts['include'],
+			'post_status'    => 'inherit',
+			'post_type'      => 'attachment',
 			'post_mime_type' => 'image,application/pdf',
-			'order' => $atts['order'],
-			'orderby' => $atts['orderby'],
+			'order'          => $atts['order'],
+			'orderby'        => $atts['orderby'],
 		) );
 
 		$attachments = array();
@@ -110,23 +110,23 @@ function hrs_gallery( $attr ) {
 	} elseif ( ! empty( $atts['exclude'] ) ) {
 		// Uses get_children to use linked attachments as the includes.
 		$attachments = get_children( array(
-			'post_parent' => $id,
-			'exclude' => $atts['exclude'],
-			'post_status' => 'inherit',
-			'post_type' => 'attachment',
+			'post_parent'    => $id,
+			'exclude'        => $atts['exclude'],
+			'post_status'    => 'inherit',
+			'post_type'      => 'attachment',
 			'post_mime_type' => 'image,application/pdf',
-			'order' => $atts['order'],
-			'orderby' => $atts['orderby'],
+			'order'          => $atts['order'],
+			'orderby'        => $atts['orderby'],
 		) );
 	} else {
 		// If no attachments are specified, default to those attached to the current post.
 		$attachments = get_children( array(
-			'post_parent' => $id,
-			'post_status' => 'inherit',
-			'post_type' => 'attachment',
+			'post_parent'    => $id,
+			'post_status'    => 'inherit',
+			'post_type'      => 'attachment',
 			'post_mime_type' => 'image,application/pdf',
-			'order' => $atts['order'],
-			'orderby' => $atts['orderby'],
+			'order'          => $atts['order'],
+			'orderby'        => $atts['orderby'],
 		) );
 	}
 
@@ -143,9 +143,9 @@ function hrs_gallery( $attr ) {
 	}
 
 	// Build elements.
-	$itemtag = tag_escape( $atts['itemtag'] );
+	$itemtag    = tag_escape( $atts['itemtag'] );
 	$captiontag = tag_escape( $atts['captiontag'] );
-	$icontag = tag_escape( $atts['icontag'] );
+	$icontag    = tag_escape( $atts['icontag'] );
 	$valid_tags = wp_kses_allowed_html( 'post' );
 
 	if ( ! isset( $valid_tags[ $itemtag ] ) ) {
@@ -158,8 +158,8 @@ function hrs_gallery( $attr ) {
 		$icontag = 'dt';
 	}
 
-	$columns = intval( $atts['columns'] );
-	$selector = "hrs-gallery-{$instance}";
+	$columns    = intval( $atts['columns'] );
+	$selector   = "hrs-gallery-{$instance}";
 	$size_class = sanitize_html_class( $atts['size'] );
 
 	$output = "<div id='{$selector}' class='gallery hrs-gallery gallery-{$id} gallery-columns-{$columns} gallery-size-{$size_class}'>";

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "scripts": {
     "clean": "rimraf assets/{css/,images/,js/}",
-    "phpcs": "vendor/bin/phpcs -v --colors --extensions=php --ignore=\"*/vendor/*,*/node_modules/*\" --standard=phpcs.ruleset.xml *.php parts/",
+    "phpcs": "vendor/bin/phpcs -v --colors --extensions=php --ignore=\"*/vendor/*,*/node_modules/*\" --standard=phpcs.ruleset.xml *.php parts/ includes/",
     "lintjs": "eslint src/assets/js/**",
     "uglify": "mkdirp assets/js && uglifyjs src/assets/js/*.js -o assets/js/custom.js -m --source-map && uglifyjs src/assets/js/*.js -o assets/js/custom.min.js -m -c",
     "lintscss": "stylelint \"src/assets/scss/**/*.scss\"",


### PR DESCRIPTION
Add a shortcode to create a gallery of document thumbnails. Essentially reproduces the default WP gallery shortcode function, but allows documents into the gallery.