### PR TITLE
Add methods to list recent posts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,18 +20,15 @@ This document details all notable changes to the WSU HRS Child Theme. Uses [Sema
 ### Removed (for deprecated features removed in this release)
 -->
 
-## (future) (unreleased)
+## 0.16.0 (2018-07-13)
 
-### Todo
+### Changed
 
-- Set max width on text-based content like posts and standard pages, open #30.
-- Set up grid fallbacks, open #31.
-- Get Babel processing working, open #35.
-
-## 0.16.0 (unreleased)
+- Update theme setup class to require the new post lists shortcode file.
 
 ### Added
 
+- Methods to retrieve and display the latest HRS posts with some filtering criteria.
 - Shortcode to display the latest HRS posts matching a given criteria.
 - Includes file to store shortcodes related to post lists.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ This document details all notable changes to the WSU HRS Child Theme. Uses [Sema
 - Set up grid fallbacks, open #31.
 - Get Babel processing working, open #35.
 
+## 0.16.0 (unreleased)
+
+### Added
+
+- Shortcode to display the latest HRS posts matching a given criteria.
+- Includes file to store shortcodes related to post lists.
+
 ## 0.15.2 (2018-07-06)
 
 ### Fixed

--- a/functions.php
+++ b/functions.php
@@ -16,7 +16,7 @@
  *
  * @since 0.7.0
  */
-$hrs_child_theme_version = '0.15.2';
+$hrs_child_theme_version = '0.16.0';
 
 /**
  * Sets up basic theme configuration and WordPress API settings.

--- a/includes/class-hrs-theme-setup.php
+++ b/includes/class-hrs-theme-setup.php
@@ -76,6 +76,8 @@ class HRS_Theme_Setup {
 		require __DIR__ . '/shortcode-document-gallery.php';
 		// The HRS last updated label shortcode.
 		require __DIR__ . '/shortcode-last-updated.php';
+		// The HRS post lists shortcodes.
+		require __DIR__ . '/shortcode-post-lists.php';
 		// The HRS template tags.
 		require __DIR__ . '/hrs-template-tags.php';
 		// WP database queries.

--- a/includes/hrs-template-tags.php
+++ b/includes/hrs-template-tags.php
@@ -107,3 +107,160 @@ function the_terms_gallery( $taxonomy ) {
 
 	echo wp_kses_post( $list );
 }
+
+/**
+ * Displays the latest HRS posts.
+ *
+ * @since 0.16.0
+ *
+ * @param array  $args {
+ *     Optional. Arguments to filter retrieval of HRS posts.
+ *
+ *     @type int $posts_per_page   Total number of posts to display. Default 5. Accepts -1 for all.
+ *     @type int $offset           Number of posts to offset return by. Default 0.
+ *     @type int|string $category  Category ID or comma-separated list of IDs to include. Detault 0.
+ *     @type string $hrs_unit      Slug of the hrs_unit taxonomy term to filter results by. Accepts
+ *                                 multiple slugs separated by either commas (to include multiple
+ *                                 categories), or plus signs (to require multiple categories).
+ *     @type string $style         The style used to display the posts list. If 'cards' posts will
+ *                                 display as individual cards in a grid. If 'list' posts will display
+ *                                 as a grid row list of flex items. Enter any other value for a custom
+ *                                 class or leave empty for no container. Default 'cards'.
+ * }
+ * @return string HTML formatted list of retrieved HRS News posts
+ */
+function hrs_recent_posts( $args = null ) {
+	global $post;
+
+	$defaults = array(
+		'posts_per_page' => 5,
+		'offset'         => 0,
+		'category'       => 0,
+		'hrs_unit'       => '',
+		'style'          => 'cards',
+	);
+
+	$query = wp_parse_args( $args, $defaults );
+	$posts = hrs_get_recent_posts( $query );
+
+	if ( ! empty( $posts ) ) :
+
+		if ( ! empty( $query['style'] ) ) {
+			if ( 'cards' === $query['style'] ) {
+				echo '<div class="recent-articles">';
+			} elseif ( 'list' === $query['style'] ) {
+				echo '<div class="articles-list">';
+			} else {
+				printf( '<div class="%s">', esc_attr( $query['style'] ) );
+			}
+		}
+
+		foreach ( $posts as $post ) {
+			setup_postdata( $post );
+			get_template_part( 'articles/archive-content' );
+		}
+
+		if ( ! empty( $query['style'] ) ) {
+			echo '</div>';
+		}
+
+	endif;
+
+	wp_reset_postdata();
+}
+
+/**
+ * Retrieve recent posts from a given taxonomy.
+ *
+ * @since 0.16.0
+ *
+ * @see WP_Query::parse_query()
+ *
+ * @param array  $args {
+ *     Optional. Arguments to filter retrieval of news posts.
+ *               See WP_Query::parse_query() for explanation of parameters.
+ *
+ *     @type int $posts_per_page   Total number of posts to display. Default 5. Accepts -1 for all.
+ *     @type int $offset           Number of posts to offset return by. Default 0.
+ *     @type int|string $category  Category ID or comma-separated list of IDs to include. Detault 0.
+ *     @type string $hrs_unit      Slug of the hrs_unit taxonomy term to filter results by. Accepts
+ *                                 multiple slugs separated by either commas (to include multiple
+ *                                 categories), or plus signs (to require multiple categories).
+ * }
+ * @return array|false List of post objects or false if no posts match request.
+ */
+function hrs_get_recent_posts( $args = null ) {
+	$defaults = array(
+		'posts_per_page' => 5,
+		'offset'         => 0,
+		'category'       => 0,
+		'hrs_unit'       => '',
+	);
+
+	$query = wp_parse_args( $args, $defaults );
+
+	if ( ! empty( $query['hrs_unit'] ) ) {
+		/*
+		 * Check for multiple terms in request:
+		 *  - comma-separated for inclusive (this OR that)
+		 *  - plus-separated for exclusive (this AND that)
+		 */
+		if ( strpos( $query['hrs_unit'], ',' ) !== false ) {
+			// Set up array with 'OR' comparison.
+			$tax_query = array(
+				'relation' => 'OR',
+			);
+
+			// Split terms into an array.
+			$units = preg_split( '/[,\s]+/', $query['hrs_unit'] );
+
+			// Build WP_Query formatted tax_query array.
+			foreach ( $units as $unit ) {
+				$or_tax = array(
+					'taxonomy' => 'hrs_unit',
+					'field'    => 'slug',
+					'terms'    => $unit,
+				);
+
+				$tax_query[] = $or_tax;
+			}
+		} elseif ( strpos( $query['hrs_unit'], '+' ) !== false ) {
+			// Set up array with 'AND' comparison.
+			$tax_query = array(
+				'relation' => 'AND',
+			);
+
+			// Split terms into an array.
+			$units = preg_split( '/[+]+/', $query['hrs_unit'] );
+
+			// Build WP_Query formatted tax_query array.
+			foreach ( $units as $unit ) {
+				$and_tax = array(
+					'taxonomy' => 'hrs_unit',
+					'field'    => 'slug',
+					'terms'    => $unit,
+				);
+
+				$tax_query[] = $and_tax;
+			}
+		} else {
+			$tax_query = array(
+				array(
+					'taxonomy' => 'hrs_unit',
+					'field'    => 'slug',
+					'terms'    => $query['hrs_unit'],
+				),
+			);
+		}
+
+		$query['tax_query'] = $tax_query;
+	}
+
+	$results = get_posts( $query );
+
+	if ( ! empty( $results ) ) {
+		return $results;
+	}
+
+	return false;
+}

--- a/includes/shortcode-post-lists.php
+++ b/includes/shortcode-post-lists.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * HRS Child Theme Posts Lists: Shortcodes
+ *
+ * @package WSU_Human_Resources_Services
+ * @since 0.13.0
+ */
+
+namespace WSU\HRS\Shortcode_Posts_Lists;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+add_shortcode( 'hrs_recent_posts', 'WSU\HRS\Shortcode_Posts_Lists\hrs_recent_posts_shortcode' );
+
+/**
+ * Shortcode displays the latest HRS posts matching criteria.
+ *
+ * Sample usage: [hrs_recent_posts]
+ *
+ * Supported attributes for the shortcode are: 'hrs_unit', 'posts_per_page',
+ * 'offset', and 'category'.
+ *
+ * @since 0.16.0
+ *
+ * @see \WSU\HRS\Template_Tags\hrs_recent_posts()
+ *
+ * @param $atts {
+ *     Optional. Arguments to filter retrieval of HRS posts.
+ *
+ *     @type int $posts_per_page   Total number of posts to display. Default 5. Accepts -1 for all.
+ *     @type int $offset           Number of posts to offset return by. Default 0.
+ *     @type int|string $category  Category ID or comma-separated list of IDs to include. Detault 0.
+ *     @type string $hrs_unit      Slug of the hrs_unit taxonomy term to filter results by. Accepts
+ *                                 multiple slugs separated by either commas (to include multiple
+ *                                 categories), or plus signs (to require multiple categories).
+ *     @type string $style         The style used to display the posts list. If 'cards' posts will
+ *                                 display as individual cards in a grid. If 'list' posts will display
+ *                                 as a grid row list of flex items. Enter any other value for a custom
+ *                                 class or leave empty for no container. Default 'cards'.
+ * @return string HTML content to display the latest HRS posts.
+ */
+function hrs_recent_posts_shortcode( $atts ) {
+	$query = shortcode_atts( array(
+		'posts_per_page' => 5,
+		'offset'         => 0,
+		'category'       => 0,
+		'hrs_unit'       => '',
+		'style'          => 'cards',
+	), $atts );
+
+	ob_start();
+
+	\WSU\HRS\Template_Tags\hrs_recent_posts( $query );
+
+	return ob_get_clean();
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hrs.wsu.edu",
-  "version": "0.15.2",
+  "version": "0.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/hrs.wsu.edu"

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -5,7 +5,7 @@ Author: Adam Turner, WSU University Communications
 Author URI: https://web.wsu.edu/
 Description: A child theme of the WSU Web Communications Spine template.
 Template: wsuspine
-Version: 0.15.2
+Version: 0.16.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Adam Turner, WSU University Communications
 Author URI: https://web.wsu.edu/
 Description: A child theme of the WSU Web Communications Spine template.
 Template: wsuspine
-Version: 0.15.2
+Version: 0.16.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
Adds several new functions to allow for displaying a list of recent posts using a template tag or shortcode anywhere on the site. Allows for some basic filtering by category or HRS Unit custom taxonomy term, and for adjusting the number of posts returned and the display style.