### PR TITLE
Update get terms methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ This document details all notable changes to the WSU HRS Child Theme. Uses [Sema
 ### Removed (for deprecated features removed in this release)
 -->
 
+## 0.17.4 (2018-07-18)
+
+### Changed
+
+- Separate retrieving and display formatting functionality between the HRS "get_terms" methods and streamline argument declaration with a default set.
+
 ## 0.17.3 (2018-07-17)
 
 ### Fixed

--- a/articles/archive-content.php
+++ b/articles/archive-content.php
@@ -38,7 +38,14 @@ global $is_feature;
 
 		<?php if ( ! is_tax( 'hrs_unit' ) && has_term( '', 'hrs_unit' ) ) : ?>
 			<footer class="article-footer article-taxonomy--primary">
-				<?php WSU\HRS\Template_Tags\the_terms( $post->ID, 'hrs_unit', false, 'ul', 'li' ); ?>
+				<?php
+				WSU\HRS\Template_Tags\the_terms( array(
+					'taxonomy'      => 'hrs_unit',
+					'show_title'    => false,
+					'container_tag' => 'ul',
+					'item_tag'      => 'li',
+				) );
+				?>
 			</footer><!-- .entry-meta -->
 		<?php endif; ?>
 

--- a/articles/post.php
+++ b/articles/post.php
@@ -91,11 +91,11 @@ use WSU\HRS\Template_Tags as Tags;
 		// get_template_part( 'parts/share-tools' );
 
 		// Print the post taxonomy lists, if they exist.
-		Tags\the_terms( get_the_ID(), 'hrs_unit' );
-		Tags\the_terms( get_the_ID(), 'category' );
-		Tags\the_terms( get_the_ID(), 'wsuwp_university_category' );
-		Tags\the_terms( get_the_ID(), 'post_tag' );
-		Tags\the_terms( get_the_ID(), 'wsuwp_university_location' );
+		Tags\the_terms( array( 'taxonomy' => 'hrs_unit' ) );
+		Tags\the_terms( array( 'taxonomy' => 'category' ) );
+		Tags\the_terms( array( 'taxonomy' => 'wsuwp_university_category' ) );
+		Tags\the_terms( array( 'taxonomy' => 'post_tag' ) );
+		Tags\the_terms( array( 'taxonomy' => 'wsuwp_university_location' ) );
 		?>
 	</footer><!-- .entry-meta -->
 

--- a/functions.php
+++ b/functions.php
@@ -34,7 +34,7 @@ add_filter( 'excerpt_more', 'hrs_excerpt_more_link' );
  * @since 0.17.3
  */
 function hrs_get_theme_version() {
-	$hrs_version = '0.17.3';
+	$hrs_version = '0.17.4';
 
 	return $hrs_version;
 }

--- a/includes/hrs-template-tags.php
+++ b/includes/hrs-template-tags.php
@@ -18,10 +18,7 @@ namespace WSU\HRS\Template_Tags;
  *
  * @param int $id Post ID
  * @param string $taxonomy The taxonomy name.
- * @param bool $show_title Optional. Whether to display the taxonomy title. Default true.
- * @param string $container_tag Optional. The HTML element used to contain the list of terms. Default is a data list (`dl` tag).
- * @param string $item_tag Optional. The HTML element used to contain each item in the list of terms. Default is a data list definition (`dd` tag).
- * @return string|false|WP_Error Array of WP_Term objects on success, false if no taxonomy or terms exist, WP_Error on failure.
+ * @return array|false|WP_Error Array of WP_Term objects on success, false if no taxonomy or terms exist, WP_Error on failure.
  */
 function get_terms( $id, $taxonomy ) {
 	if ( ! isset( $taxonomy ) || ! taxonomy_exists( $taxonomy ) ) {
@@ -52,11 +49,15 @@ function get_terms( $id, $taxonomy ) {
  *
  * @since 0.14.0
  *
- * @param int $id Post ID
- * @param string $taxonomy The taxonomy name.
- * @param bool $show_title Optional. Whether to display the taxonomy title. Default true.
- * @param string $container_tag Optional. The HTML element used to contain the list of terms. Default is a data list (`dl` tag).
- * @param string $item_tag Optional. The HTML element used to contain each item in the list of terms. Default is a data list definition (`dd` tag).
+ * @param array $args {
+ *     Optional. Arguments to filter retrieval of HRS posts.
+ *
+ *     @type int    $id            Post ID
+ *     @type string $taxonomy      The taxonomy name.
+ *     @type bool   $show_title    Whether to display the taxonomy title. Default true.
+ *     @type string $container_tag The HTML element used to contain the list of terms. Default is a data list (`dl` tag).
+ *     @type string $item_tag      The HTML element used to contain each item in the list of terms. Default is a data list definition (`dd` tag).
+ * }
  * @return string|false HTML formatted list of terms or false if no terms exist or on WordPress error.
  */
 function the_terms( $args = array() ) {

--- a/includes/hrs-template-tags.php
+++ b/includes/hrs-template-tags.php
@@ -21,25 +21,19 @@ namespace WSU\HRS\Template_Tags;
  * @param bool $show_title Optional. Whether to display the taxonomy title. Default true.
  * @param string $container_tag Optional. The HTML element used to contain the list of terms. Default is a data list (`dl` tag).
  * @param string $item_tag Optional. The HTML element used to contain each item in the list of terms. Default is a data list definition (`dd` tag).
- * @return string|false|WP_Error List of terms on success, false if no taxonomy or terms exist, WP_Error on failure.
+ * @return string|false|WP_Error Array of WP_Term objects on success, false if no taxonomy or terms exist, WP_Error on failure.
  */
-function get_terms( $id, $taxonomy, $show_title = true, $container_tag = 'dl', $item_tag = 'dd' ) {
-
+function get_terms( $id, $taxonomy ) {
 	if ( ! isset( $taxonomy ) || ! taxonomy_exists( $taxonomy ) ) {
 		return false;
 	}
 
-	$taxonomy_obj = get_taxonomy( $taxonomy );
-
 	if ( 'category' === $taxonomy ) {
-		$terms      = get_the_category();
-		$term_title = __( 'Categorized' );
+		$terms = get_the_category();
 	} elseif ( 'post_tag' === $taxonomy ) {
-		$terms      = get_the_tags();
-		$term_title = __( 'Tagged' );
+		$terms = get_the_tags();
 	} else {
-		$terms      = get_the_terms( $id, $taxonomy );
-		$term_title = $taxonomy_obj->labels->singular_name;
+		$terms = get_the_terms( $id, $taxonomy );
 	}
 
 	if ( is_wp_error( $terms ) ) {
@@ -50,19 +44,7 @@ function get_terms( $id, $taxonomy, $show_title = true, $container_tag = 'dl', $
 		return false;
 	}
 
-	$container_start = '<' . $container_tag . ' class="article-taxonomy ' . esc_attr( $taxonomy ) . '">';
-	$container_end   = '</' . $container_tag . '>';
-	$term_title      = ( true === $show_title ) ? '<dt>' . esc_html( $term_title ) . '</dt>' : '';
-	$terms_list      = array();
-
-	foreach ( $terms as $term ) {
-		$term_link = get_term_link( $term->term_id, $taxonomy );
-		if ( ! is_wp_error( $term_link ) ) {
-				$terms_list[] = '<' . $item_tag . '><a href="' . esc_url( $term_link ) . '">' . esc_html( $term->name ) . '</a></' . $item_tag . '>';
-		}
-	}
-
-	return $container_start . $term_title . join( '', $terms_list ) . $container_end;
+	return $terms;
 }
 
 /**
@@ -75,16 +57,68 @@ function get_terms( $id, $taxonomy, $show_title = true, $container_tag = 'dl', $
  * @param bool $show_title Optional. Whether to display the taxonomy title. Default true.
  * @param string $container_tag Optional. The HTML element used to contain the list of terms. Default is a data list (`dl` tag).
  * @param string $item_tag Optional. The HTML element used to contain each item in the list of terms. Default is a data list definition (`dd` tag).
- * @return false|void False on WordPress error.
+ * @return string|false HTML formatted list of terms or false if no terms exist or on WordPress error.
  */
-function the_terms( $id, $taxonomy, $show_title = true, $container_tag = 'dl', $item_tag = 'dd' ) {
-	$terms_list = \WSU\HRS\Template_Tags\get_terms( $id, $taxonomy, $show_title, $container_tag, $item_tag );
+function the_terms( $args = array() ) {
+	$defaults = array(
+		'id'            => get_the_ID(),
+		'taxonomy'      => '',
+		'show_title'    => true,
+		'container_tag' => 'dl',
+		'item_tag'      => 'dd',
+	);
 
-	if ( is_wp_error( $terms_list ) ) {
+	$atts = wp_parse_args( $args, $defaults );
+
+	if ( ! isset( $atts['taxonomy'] ) || ! taxonomy_exists( $atts['taxonomy'] ) ) {
 		return false;
 	}
 
-	echo wp_kses_post( $terms_list );
+	$terms = \WSU\HRS\Template_Tags\get_terms( $atts['id'], $atts['taxonomy'] );
+
+	if ( is_wp_error( $terms ) || empty( $terms ) ) {
+		return false;
+	}
+
+	if ( true === $atts['show_title'] ) {
+		if ( 'category' === $atts['taxonomy'] ) {
+			$term_title = '<dt>' . __( 'Categorized', 'hrs-wsu-edu' ) . '</dt>';
+		} elseif ( 'post_tag' === $atts['taxonomy'] ) {
+			$term_title = '<dt>' . __( 'Tagged', 'hrs-wsu-edu' ) . '</dt>';
+		} else {
+			$taxonomy_obj = get_taxonomy( $atts['taxonomy'] );
+			/* translators: The taxonomy name in singular tense */
+			$term_title = sprintf( __( '<dt>%s</dt>', 'hrs-wsu-edu' ),
+				esc_html( $taxonomy_obj->labels->singular_name )
+			);
+		}
+	} else {
+		$term_title = '';
+	}
+
+	$terms_list = array();
+
+	foreach ( $terms as $term ) {
+		$term_link = get_term_link( $term->term_id, $atts['taxonomy'] );
+		if ( ! is_wp_error( $term_link ) ) {
+			/* translators: 1: the list item element tag, 2: the term URL, 3: the term name */
+			$terms_list[] = sprintf( __( '<%1$s><a href="%2$s">%3$s</a></%1$s>', 'hrs-wsu-edu' ),
+				$atts['item_tag'],
+				esc_url( $term_link ),
+				esc_html( $term->name )
+			);
+		}
+	}
+
+	/* translators: 1: the container element tag name, 2: the containing element class name(s), 3: one or more list items containing term links and names, 4: the taxonomy name */
+	$html = sprintf( __( '<%1$s class="class="article-taxonomy %2$s">%4$s%3$s</%1$s>', 'hrs-wsu-edu' ),
+		esc_html( $atts['container_tag'] ),
+		esc_attr( $atts['taxonomy'] ),
+		join( '', $terms_list ),
+		$term_title
+	);
+
+	echo wp_kses_post( $html );
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hrs.wsu.edu",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/washingtonstateuniversity/hrs.wsu.edu"

--- a/parts/single-layout.php
+++ b/parts/single-layout.php
@@ -17,7 +17,14 @@
 
 			<div class="column one">
 
-				<?php WSU\HRS\Template_Tags\the_terms( $post->ID, 'hrs_unit', false, 'ul', 'li' ); ?>
+				<?php
+				WSU\HRS\Template_Tags\the_terms( array(
+					'taxonomy'      => 'hrs_unit',
+					'show_title'    => false,
+					'container_tag' => 'ul',
+					'item_tag'      => 'li',
+				) );
+				?>
 
 			</div><!--/column-->
 

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -5,7 +5,7 @@ Author: Adam Turner, WSU University Communications
 Author URI: https://web.wsu.edu/
 Description: A child theme of the WSU Web Communications Spine template.
 Template: wsuspine
-Version: 0.17.3
+Version: 0.17.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */

--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ Author: Adam Turner, WSU University Communications
 Author URI: https://web.wsu.edu/
 Description: A child theme of the WSU Web Communications Spine template.
 Template: wsuspine
-Version: 0.17.3
+Version: 0.17.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */


### PR DESCRIPTION
Updated the get terms methods to separate their concerns more cleanly -- `get_terms()` now only retrieves an array of term objects and `the_terms()` only handles formatting and outputting those terms as HTML lists. Also changed the parameters to make them clearer on the function definition and call sides using an array of arguments instead of a list.