### PR TITLE
:bug: Fix #127 include footer in builder template

### DIFF
--- a/inc/wsu-spine.php
+++ b/inc/wsu-spine.php
@@ -185,6 +185,16 @@ function remove_spine_filters() {
 }
 
 /**
+ * Includes the HRSWP footer template in the Builder template.
+ *
+ * @since 2.0.0
+ */
+function include_hrswp_footer_in_builder() {
+	get_template_part( 'build/templates/footer' );
+}
+add_action( 'spine_theme_template_after_footer', __NAMESPACE__ . '\include_hrswp_footer_in_builder' );
+
+/**
  * Sets the Spine version for this site.
  *
  * Retrieves the Spine version if it exists, and calls the setter if it


### PR DESCRIPTION
## Description

Hook an action into the parent theme's Builder template to include the child theme footer.

## How has this been tested?

Works as expected in local development environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
