### PR TITLE
Fix site header aria label

### DIFF
--- a/build/templates/header.php
+++ b/build/templates/header.php
@@ -14,7 +14,7 @@
 namespace HrswpTheme\templates\header;
 
 ?>
-<header class="site-header" aria-label="hrs-website">
+<header class="site-header" aria-label="HRS Site Header">
 	<section class="row single">
 		<div class="site-banner column one">
 			<a class="site-title" href="<?php echo esc_url( home_url() ); ?>">Human Resource Services</a>

--- a/src/templates/header/index.php
+++ b/src/templates/header/index.php
@@ -14,7 +14,7 @@
 namespace HrswpTheme\templates\header;
 
 ?>
-<header class="site-header" aria-label="hrs-website">
+<header class="site-header" aria-label="HRS Site Header">
 	<section class="row single">
 		<div class="site-banner column one">
 			<a class="site-title" href="<?php echo esc_url( home_url() ); ?>">Human Resource Services</a>


### PR DESCRIPTION
## Description

Makes the HRS site header aria label more readable.

## How has this been tested?

Works as expected in local dev environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
