### PR TITLE
Fix to allow GPL 3.0 license in npm license

### DIFF
--- a/.npmpackagejsonlintrc.json
+++ b/.npmpackagejsonlintrc.json
@@ -1,3 +1,6 @@
 {
-	"extends": "@wordpress/npm-package-json-lint-config"
+	"extends": "@wordpress/npm-package-json-lint-config",
+	"rules": {
+		"valid-values-license": "off"
+	}
 }


### PR DESCRIPTION
## Description

Amend WordPress NPM Package JSON Lint config rules to allow the GPL 3.0 license. WordPress only allows the 2.0 license in their rules.

## How has this been tested?

Works as expected to lint `package.json` locally.

## Checklist:

- [x] My code is tested.
