### PR TITLE
Fix php lint issues

### DIFF
--- a/build/components/terms-list.php
+++ b/build/components/terms-list.php
@@ -59,7 +59,7 @@ function the_terms( $args = array() ) {
 		} else {
 			$taxonomy_obj = get_taxonomy( $atts['taxonomy'] );
 			/* translators: The taxonomy name in singular tense */
-			$term_title = sprintf( __( '<dt>%s</dt>', 'hrswp-theme' ), esc_html( $taxonomy_obj->labels->singular_name ) );
+			$term_title = sprintf( '<dt>%s</dt>', esc_html( $taxonomy_obj->labels->singular_name ) );
 		}
 	} else {
 		$term_title = '';

--- a/build/editor.asset.php
+++ b/build/editor.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-polyfill'), 'version' => '614e34d82b322b6b0330616fb24288a8');
+<?php return array('dependencies' => array('wp-polyfill'), 'version' => 'bde801cdd17ec720f666a724eca076ab');

--- a/build/index.asset.php
+++ b/build/index.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('wp-polyfill'), 'version' => 'fcb5ee0ef269af33e9dd5ee3a0cbde8b');
+<?php return array('dependencies' => array('wp-polyfill'), 'version' => '1e44000daa9389549a3528d6d47e1fd1');

--- a/inc/gravityforms.php
+++ b/inc/gravityforms.php
@@ -60,10 +60,9 @@ add_action( 'after_setup_theme', __NAMESPACE__ . '\gravityforms_setup' );
  * @param object $field      The current field.
  * @param string $text       The current column name.
  * @param string $value      The currently entered/selected value for the column's input.
- * @param int    $form_id    The ID of the current form.
  * @return string The HTML content of the List field column.
  */
-function hrs_filter_evals_reason_column( $input, $input_info, $field, $text, $value, $form_id ) {
+function hrs_filter_evals_reason_column( $input, $input_info, $field, $text, $value ) {
 	$input_field_name = 'input_' . $field->id . '[]';
 	$tabindex         = GFCommon::get_tabindex();
 

--- a/src/components/terms-list/index.php
+++ b/src/components/terms-list/index.php
@@ -59,7 +59,7 @@ function the_terms( $args = array() ) {
 		} else {
 			$taxonomy_obj = get_taxonomy( $atts['taxonomy'] );
 			/* translators: The taxonomy name in singular tense */
-			$term_title = sprintf( __( '<dt>%s</dt>', 'hrswp-theme' ), esc_html( $taxonomy_obj->labels->singular_name ) );
+			$term_title = sprintf( '<dt>%s</dt>', esc_html( $taxonomy_obj->labels->singular_name ) );
 		}
 	} else {
 		$term_title = '';


### PR DESCRIPTION
## Description

Updated WP PHP coding standards config flagged several PHP issues. Fix attempt to translate a string and an unused function parameter.

## How has this been tested?

Works as expected in local environment.

## Types of changes

Linting fixes.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
