### PR TITLE
A11y/distinguishable landmarks

### DIFF
--- a/build/components/search-menu.php
+++ b/build/components/search-menu.php
@@ -22,11 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		wp_nav_menu(
 			array(
-				'theme_location' => 'hrs-search-menu',
-				'menu'           => 'hrs-search-menu',
-				'container'      => 'nav',
-				'items_wrap'     => '<ul>%3$s</ul>',
-				'depth'          => 2,
+				'theme_location'       => 'hrs-search-menu',
+				'menu'                 => 'hrs-search-menu',
+				'container'            => 'nav',
+				'container_aria_label' => 'Common searches',
+				'items_wrap'           => '<ul>%3$s</ul>',
+				'depth'                => 2,
 			)
 		);
 		?>

--- a/build/templates/archive.php
+++ b/build/templates/archive.php
@@ -12,11 +12,11 @@ use HrswpTheme\components\terms_lists;
 global $is_feature;
 ?>
 
-	<article id="post-<?php the_ID(); ?>" <?php post_class( 'archive-content' ); ?>>
+	<article id="post-<?php the_ID(); ?>" <?php post_class( 'archive-content' ); ?> aria-labelledby="article-<?php the_ID(); ?>-title">
 
 		<header class="article-header">
 			<p class="article-title">
-				<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+				<a id="article-<?php the_ID(); ?>-title" href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
 			</p>
 			<?php if ( is_search() ) : ?>
 				<span class="meta"><?php the_permalink(); ?></span>

--- a/build/templates/footer.php
+++ b/build/templates/footer.php
@@ -15,27 +15,29 @@ namespace HrswpTheme\templates\footer;
 
 // Arguments for the WP nav menus in the site footer.
 $footer_nav_args = array(
-	'theme_location'  => 'hrs-site-footer',
-	'menu'            => 'hrs-site-footer',
-	'container'       => 'nav',
-	'container_class' => false,
-	'container_id'    => false,
-	'menu_class'      => null,
-	'menu_id'         => null,
-	'items_wrap'      => '<span class="footer-nav-title">' . __( 'About', 'hrswp-theme' ) . '</span><ul>%3$s</ul>',
-	'depth'           => 4,
+	'theme_location'       => 'hrs-site-footer',
+	'menu'                 => 'hrs-site-footer',
+	'container'            => 'nav',
+	'container_class'      => false,
+	'container_id'         => false,
+	'container_aria_label' => 'About HRS',
+	'menu_class'           => null,
+	'menu_id'              => null,
+	'items_wrap'           => '<span class="footer-nav-title">' . __( 'About', 'hrswp-theme' ) . '</span><ul>%3$s</ul>',
+	'depth'                => 4,
 );
 
 $site_reference_args = array(
-	'theme_location'  => 'site-reference',
-	'menu'            => 'site-reference',
-	'container'       => 'nav',
-	'container_class' => 'site-reference',
-	'container_id'    => false,
-	'menu_class'      => null,
-	'menu_id'         => null,
-	'items_wrap'      => '<ul>%3$s</ul>',
-	'depth'           => 1,
+	'theme_location'       => 'site-reference',
+	'menu'                 => 'site-reference',
+	'container'            => 'nav',
+	'container_class'      => 'site-reference',
+	'container_id'         => false,
+	'container_aria_label' => 'Policies and contact',
+	'menu_class'           => null,
+	'menu_id'              => null,
+	'items_wrap'           => '<ul>%3$s</ul>',
+	'depth'                => 1,
 );
 ?>
 

--- a/build/templates/page.php
+++ b/build/templates/page.php
@@ -11,11 +11,11 @@
 namespace HrswpTheme\templates\single;
 
 ?>
-<article id="post-<?php the_ID(); ?>" <?php post_class( 'article-content' ); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'article-content' ); ?> aria-labelledby="article-title">
 
 	<?php if ( true === spine_get_option( 'articletitle_show' ) ) : ?>
 		<header class="article-header">
-			<h1 class="article-title"><?php the_title(); ?></h1>
+			<h1 id="article-title" class="article-title"><?php the_title(); ?></h1>
 		</header>
 	<?php endif; ?>
 

--- a/src/components/search-menu/index.php
+++ b/src/components/search-menu/index.php
@@ -22,11 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php
 		wp_nav_menu(
 			array(
-				'theme_location' => 'hrs-search-menu',
-				'menu'           => 'hrs-search-menu',
-				'container'      => 'nav',
-				'items_wrap'     => '<ul>%3$s</ul>',
-				'depth'          => 2,
+				'theme_location'       => 'hrs-search-menu',
+				'menu'                 => 'hrs-search-menu',
+				'container'            => 'nav',
+				'container_aria_label' => 'Common searches',
+				'items_wrap'           => '<ul>%3$s</ul>',
+				'depth'                => 2,
 			)
 		);
 		?>

--- a/src/templates/archive/index.php
+++ b/src/templates/archive/index.php
@@ -12,11 +12,11 @@ use HrswpTheme\components\terms_lists;
 global $is_feature;
 ?>
 
-	<article id="post-<?php the_ID(); ?>" <?php post_class( 'archive-content' ); ?>>
+	<article id="post-<?php the_ID(); ?>" <?php post_class( 'archive-content' ); ?> aria-labelledby="article-<?php the_ID(); ?>-title">
 
 		<header class="article-header">
 			<p class="article-title">
-				<a href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
+				<a id="article-<?php the_ID(); ?>-title" href="<?php the_permalink(); ?>" rel="bookmark"><?php the_title(); ?></a>
 			</p>
 			<?php if ( is_search() ) : ?>
 				<span class="meta"><?php the_permalink(); ?></span>

--- a/src/templates/footer/index.php
+++ b/src/templates/footer/index.php
@@ -15,27 +15,29 @@ namespace HrswpTheme\templates\footer;
 
 // Arguments for the WP nav menus in the site footer.
 $footer_nav_args = array(
-	'theme_location'  => 'hrs-site-footer',
-	'menu'            => 'hrs-site-footer',
-	'container'       => 'nav',
-	'container_class' => false,
-	'container_id'    => false,
-	'menu_class'      => null,
-	'menu_id'         => null,
-	'items_wrap'      => '<span class="footer-nav-title">' . __( 'About', 'hrswp-theme' ) . '</span><ul>%3$s</ul>',
-	'depth'           => 4,
+	'theme_location'       => 'hrs-site-footer',
+	'menu'                 => 'hrs-site-footer',
+	'container'            => 'nav',
+	'container_class'      => false,
+	'container_id'         => false,
+	'container_aria_label' => 'About HRS',
+	'menu_class'           => null,
+	'menu_id'              => null,
+	'items_wrap'           => '<span class="footer-nav-title">' . __( 'About', 'hrswp-theme' ) . '</span><ul>%3$s</ul>',
+	'depth'                => 4,
 );
 
 $site_reference_args = array(
-	'theme_location'  => 'site-reference',
-	'menu'            => 'site-reference',
-	'container'       => 'nav',
-	'container_class' => 'site-reference',
-	'container_id'    => false,
-	'menu_class'      => null,
-	'menu_id'         => null,
-	'items_wrap'      => '<ul>%3$s</ul>',
-	'depth'           => 1,
+	'theme_location'       => 'site-reference',
+	'menu'                 => 'site-reference',
+	'container'            => 'nav',
+	'container_class'      => 'site-reference',
+	'container_id'         => false,
+	'container_aria_label' => 'Policies and contact',
+	'menu_class'           => null,
+	'menu_id'              => null,
+	'items_wrap'           => '<ul>%3$s</ul>',
+	'depth'                => 1,
 );
 ?>
 

--- a/src/templates/page/index.php
+++ b/src/templates/page/index.php
@@ -11,11 +11,11 @@
 namespace HrswpTheme\templates\single;
 
 ?>
-<article id="post-<?php the_ID(); ?>" <?php post_class( 'article-content' ); ?>>
+<article id="post-<?php the_ID(); ?>" <?php post_class( 'article-content' ); ?> aria-labelledby="article-title">
 
 	<?php if ( true === spine_get_option( 'articletitle_show' ) ) : ?>
 		<header class="article-header">
-			<h1 class="article-title"><?php the_title(); ?></h1>
+			<h1 id="article-title" class="article-title"><?php the_title(); ?></h1>
 		</header>
 	<?php endif; ?>
 


### PR DESCRIPTION
## Description

Fix #87 along with general missing ARIA labels on generic landmark regions.

## How has this been tested?

Works as expected in local environment, passing Siteimprove accessibility checker tests.

## Types of changes

Adjustments to markup to add ARIA `label`s and `labelledby`s to landmark regions, particularly `nav` and `article` elements.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
