### PR TITLE
Disable WP core block patterns

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -57,6 +57,9 @@ function theme_supports() {
 	add_theme_support( 'disable-custom-colors' );
 	add_theme_support( 'disable-custom-font-sizes' );
 
+	// Disable the WP Core block patterns.
+	remove_theme_support( 'core-block-patterns' );
+
 	// Only allow certain users to adjust colors.
 	if ( ! current_user_can( 'publish_posts' ) ) {
 


### PR DESCRIPTION
## Description

WordPress 5.5 introduced Patterns and shipped with several built-in patterns that we don't want. Disable them.

## How has this been tested?

Works as expected in local environment.

## Types of changes

Remove built-in theme support.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
