### PR TITLE
Disable WP block gradients

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -55,6 +55,8 @@ function theme_supports() {
 
 	// Disables some custom Gutenberg block options.
 	add_theme_support( 'disable-custom-colors' );
+	add_theme_support( 'disable-custom-gradients' );
+	add_theme_support( 'editor-gradient-presets', array() );
 	add_theme_support( 'disable-custom-font-sizes' );
 
 	// Only allow certain users to adjust colors.


### PR DESCRIPTION
## Description

WP ships with gradient options enabled for backgrounds on things like the button and cover block. We don't use these, so disable them.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
