### PR TITLE
Fix #164 TablePress class misreferenced

### DIFF
--- a/inc/tablepress.php
+++ b/inc/tablepress.php
@@ -69,7 +69,7 @@ function tablepress_attributes_filter( $tag_attributes, $table_id, $cell_content
 	$table_props = get_transient( 'hrswp_tablepress_header_columns' );
 
 	if ( false === $table_props ) {
-		$table       = TablePress::$model_table->load( $table_id );
+		$table       = \TablePress::$model_table->load( $table_id );
 		$table_props = array(
 			'header_row' => $table['data'][0],
 		);


### PR DESCRIPTION
## Description

Fix #164 TablePress tables throwing an error because of a typo in a filter calling the TablePress class.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
