### PR TITLE
Ignore new config files for zip downloads

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,14 +5,16 @@
 .gitattributes export-ignore
 .gitignore export-ignore
 .npmpackagejsonlintrc.json export-ignore
+.phpcs.xml.dist export-ignore
+.prettierrc.js export-ignore
 .stylelintrc.json export-ignore
 .travis.yml export-ignore
+CHANGELOG.md export-ignore
 composer.json export-ignore
 composer.lock export-ignore
 CONTRIBUTING.md export-ignore
 package.json export-ignore
 package-lock.json export-ignore
-phpcs.xml.dist export-ignore
 postcss.config.js export-ignore
 webpack.config.js export-ignore
 /.github export-ignore


### PR DESCRIPTION
## Description

Assign `.prettierrc.js`, `.phpcs.xml.dist`, and `CHANGELOG.md` as `export-ignore` to prevent them from being included in zip exports.

## How has this been tested?

Works as expected on download.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
