### PR TITLE
Remove "protected" prefix from page titles

### DIFF
--- a/inc/content-filters.php
+++ b/inc/content-filters.php
@@ -62,3 +62,13 @@ function excerpt_more_link_content( $more_string ) {
 	return $more_string;
 }
 add_filter( 'excerpt_more', __NAMESPACE__ . '\excerpt_more_link_content' );
+
+/**
+ * Removes the "Protected" prefix from protected page titles.
+ *
+ * @since 2.1.0
+ */
+function filter_protected_title_format() {
+	return '%s';
+}
+add_filter( 'protected_title_format', __NAMESPACE__ . '\filter_protected_title_format' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7201,9 +7201,9 @@
 			"dev": true
 		},
 		"ini": {
-			"version": "1.3.5",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+			"integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
 			"dev": true
 		},
 		"internal-slot": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@washingtonstateuniversity/hrs.wsu.edu",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -5513,9 +5513,9 @@
 			}
 		},
 		"dot-prop": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-			"integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+			"integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
 			"dev": true,
 			"requires": {
 				"is-obj": "^1.0.0"


### PR DESCRIPTION
## Description

Fix #187 Remove "protected" prefix from page titles that are set to password protected. Display only the title.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
