### PR TITLE
Babel updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.5.tgz",
-			"integrity": "sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.12.7.tgz",
+			"integrity": "sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==",
 			"dev": true
 		},
 		"@babel/core": {
@@ -153,61 +153,27 @@
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
-			"integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.12.10.tgz",
+			"integrity": "sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-binary-assignment-operator-visitor": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
-			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-explode-assignable-expression": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-react-jsx": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx/-/helper-builder-react-jsx-7.10.4.tgz",
-			"integrity": "sha512-5nPcIZ7+KKDxT1427oBivl9V9YTal7qk0diccnh7RrcgrT/pGFOjgGw1dgryyx1GvHEpXVfoDF6Ak3rTiWh8Rg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-builder-react-jsx-experimental": {
-			"version": "7.12.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz",
-			"integrity": "sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-module-imports": "^7.12.1",
-				"@babel/types": "^7.12.1"
+				"@babel/types": "^7.12.10"
 			},
 			"dependencies": {
-				"@babel/helper-module-imports": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
-					"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
-					"dev": true,
-					"requires": {
-						"@babel/types": "^7.12.5"
-					}
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -218,6 +184,16 @@
 					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
 				}
+			}
+		},
+		"@babel/helper-builder-binary-assignment-operator-visitor": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.10.4.tgz",
+			"integrity": "sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-explode-assignable-expression": "^7.10.4",
+				"@babel/types": "^7.10.4"
 			}
 		},
 		"@babel/helper-compilation-targets": {
@@ -233,40 +209,34 @@
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.14.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-					"integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+					"version": "4.16.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+					"integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001157",
+						"caniuse-lite": "^1.0.30001173",
 						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.591",
+						"electron-to-chromium": "^1.3.634",
 						"escalade": "^3.1.1",
-						"node-releases": "^1.1.66"
+						"node-releases": "^1.1.69"
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001159",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-					"integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
+					"version": "1.0.30001173",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
+					"integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
 					"dev": true
 				},
 				"electron-to-chromium": {
-					"version": "1.3.603",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz",
-					"integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==",
-					"dev": true
-				},
-				"escalade": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+					"version": "1.3.634",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz",
+					"integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==",
 					"dev": true
 				},
 				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+					"version": "1.1.69",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+					"integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
 					"dev": true
 				},
 				"semver": {
@@ -291,45 +261,71 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/helper-optimise-call-expression": {
+							"version": "7.12.10",
+							"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+							"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.10"
+							}
+						}
 					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -343,35 +339,68 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
-				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-function-name": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+							"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-get-function-arity": "^7.12.10",
+								"@babel/template": "^7.12.7",
+								"@babel/types": "^7.12.11"
+							}
+						},
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -441,13 +470,12 @@
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
-			"integrity": "sha512-rsZ4LGvFTZnzdNZR5HZdmJVuXK8834R5QkF3WvcnBhrlVtF0HSIUC6zbreL9MgjTywhKokn8RIYRiq99+DLAxA==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.7.tgz",
+			"integrity": "sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-annotate-as-pure": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4",
 				"regexpu-core": "^4.7.1"
 			}
 		},
@@ -479,13 +507,19 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -583,23 +617,6 @@
 			"integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==",
 			"dev": true
 		},
-		"@babel/helper-regex": {
-			"version": "7.10.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-regex/-/helper-regex-7.10.5.tgz",
-			"integrity": "sha512-68kdUAzDrljqBrio7DYAEgCoJHxppJOERHOgOrDN7WjOzP0ZQ1LsSDRXcemzVZaLvjaJsJEESb6qt+znNuENDg==",
-			"dev": true,
-			"requires": {
-				"lodash": "^4.17.19"
-			},
-			"dependencies": {
-				"lodash": {
-					"version": "4.17.20",
-					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-					"dev": true
-				}
-			}
-		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.12.1",
 			"resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.12.1.tgz",
@@ -611,13 +628,19 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -661,13 +684,19 @@
 				"@babel/types": "^7.12.1"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -696,9 +725,9 @@
 			"dev": true
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz",
-			"integrity": "sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz",
+			"integrity": "sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==",
 			"dev": true
 		},
 		"@babel/helper-wrap-function": {
@@ -794,9 +823,9 @@
 			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz",
-			"integrity": "sha512-d+/o30tJxFxrA1lhzJqiUcEJdI6jKlNregCv5bASeGf2Q4MXmnwH7viDo7nhx1/ohf09oaH8j1GVYG/e3Yqk6A==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.12.tgz",
+			"integrity": "sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -865,9 +894,9 @@
 			}
 		},
 		"@babel/plugin-proposal-numeric-separator": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz",
-			"integrity": "sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz",
+			"integrity": "sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -896,9 +925,9 @@
 			}
 		},
 		"@babel/plugin-proposal-optional-chaining": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz",
-			"integrity": "sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz",
+			"integrity": "sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4",
@@ -1072,13 +1101,19 @@
 						"@babel/types": "^7.12.5"
 					}
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1101,9 +1136,9 @@
 			}
 		},
 		"@babel/plugin-transform-block-scoping": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz",
-			"integrity": "sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz",
+			"integrity": "sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -1126,45 +1161,71 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/helper-optimise-call-expression": {
+							"version": "7.12.10",
+							"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+							"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.10"
+							}
+						}
 					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -1178,35 +1239,68 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
-				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-function-name": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+							"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+							"dev": true,
+							"requires": {
+								"@babel/helper-get-function-arity": "^7.12.10",
+								"@babel/template": "^7.12.7",
+								"@babel/types": "^7.12.11"
+							}
+						},
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -1371,32 +1465,65 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -1425,16 +1552,25 @@
 						"lodash": "^4.17.19"
 					}
 				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -1458,37 +1594,56 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
 				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
 					}
 				},
 				"ansi-styles": {
@@ -1568,32 +1723,65 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -1622,16 +1810,25 @@
 						"lodash": "^4.17.19"
 					}
 				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -1655,37 +1852,56 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
 				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
 					}
 				},
 				"ansi-styles": {
@@ -1766,32 +1982,65 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -1820,16 +2069,25 @@
 						"lodash": "^4.17.19"
 					}
 				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -1853,37 +2111,56 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
 				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
 					}
 				},
 				"ansi-styles": {
@@ -1961,32 +2238,65 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
 					}
 				},
 				"@babel/helper-module-imports": {
@@ -2015,16 +2325,25 @@
 						"lodash": "^4.17.19"
 					}
 				},
-				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/helper-simple-access": {
@@ -2048,37 +2367,56 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
 				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
 					"dev": true,
 					"requires": {
-						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
 					}
 				},
 				"ansi-styles": {
@@ -2174,45 +2512,89 @@
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
 					}
 				},
 				"@babel/generator": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.5.tgz",
-					"integrity": "sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.5",
+						"@babel/types": "^7.12.11",
 						"jsesc": "^2.5.1",
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.12.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
-					"integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
 					"dev": true,
 					"requires": {
-						"@babel/types": "^7.12.1"
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
 					}
 				},
 				"@babel/helper-replace-supers": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz",
-					"integrity": "sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.12.1",
-						"@babel/helper-optimise-call-expression": "^7.10.4",
-						"@babel/traverse": "^7.12.5",
-						"@babel/types": "^7.12.5"
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
 					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
 				},
 				"@babel/highlight": {
 					"version": "7.10.4",
@@ -2226,35 +2608,46 @@
 					}
 				},
 				"@babel/parser": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
-					"integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
 					"dev": true
 				},
-				"@babel/traverse": {
-					"version": "7.12.5",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.5.tgz",
-					"integrity": "sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==",
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
 					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.10.4",
-						"@babel/generator": "^7.12.5",
-						"@babel/helper-function-name": "^7.10.4",
-						"@babel/helper-split-export-declaration": "^7.11.0",
-						"@babel/parser": "^7.12.5",
-						"@babel/types": "^7.12.5",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
 						"debug": "^4.1.0",
 						"globals": "^11.1.0",
 						"lodash": "^4.17.19"
 					}
 				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -2342,15 +2735,50 @@
 			}
 		},
 		"@babel/plugin-transform-react-jsx": {
-			"version": "7.12.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.5.tgz",
-			"integrity": "sha512-2xkcPqqrYiOQgSlM/iwto1paPijjsDbUynN13tI6bosDz/jOW3CRzYguIE8wKX32h+msbBM22Dv5fwrFkUOZjQ==",
+			"version": "7.12.12",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.12.tgz",
+			"integrity": "sha512-JDWGuzGNWscYcq8oJVCtSE61a5+XAOos+V0HrxnDieUus4UMnBEosDnY1VJqU5iZ4pA04QY7l0+JvHL1hZEfsw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-builder-react-jsx": "^7.10.4",
-				"@babel/helper-builder-react-jsx-experimental": "^7.12.1",
+				"@babel/helper-annotate-as-pure": "^7.12.10",
+				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/plugin-syntax-jsx": "^7.12.1"
+				"@babel/plugin-syntax-jsx": "^7.12.1",
+				"@babel/types": "^7.12.12"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+					"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.5"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
@@ -2372,14 +2800,13 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.1.tgz",
-			"integrity": "sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz",
+			"integrity": "sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
 			},
 			"dependencies": {
@@ -2392,13 +2819,19 @@
 						"@babel/types": "^7.12.5"
 					}
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -2437,13 +2870,12 @@
 			}
 		},
 		"@babel/plugin-transform-sticky-regex": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz",
-			"integrity": "sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz",
+			"integrity": "sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-regex": "^7.10.4"
+				"@babel/helper-plugin-utils": "^7.10.4"
 			}
 		},
 		"@babel/plugin-transform-template-literals": {
@@ -2456,9 +2888,9 @@
 			}
 		},
 		"@babel/plugin-transform-typeof-symbol": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz",
-			"integrity": "sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz",
+			"integrity": "sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==",
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.10.4"
@@ -2484,16 +2916,16 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.1.tgz",
-			"integrity": "sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.12.11.tgz",
+			"integrity": "sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==",
 			"dev": true,
 			"requires": {
-				"@babel/compat-data": "^7.12.1",
-				"@babel/helper-compilation-targets": "^7.12.1",
-				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/compat-data": "^7.12.7",
+				"@babel/helper-compilation-targets": "^7.12.5",
+				"@babel/helper-module-imports": "^7.12.5",
 				"@babel/helper-plugin-utils": "^7.10.4",
-				"@babel/helper-validator-option": "^7.12.1",
+				"@babel/helper-validator-option": "^7.12.11",
 				"@babel/plugin-proposal-async-generator-functions": "^7.12.1",
 				"@babel/plugin-proposal-class-properties": "^7.12.1",
 				"@babel/plugin-proposal-dynamic-import": "^7.12.1",
@@ -2501,10 +2933,10 @@
 				"@babel/plugin-proposal-json-strings": "^7.12.1",
 				"@babel/plugin-proposal-logical-assignment-operators": "^7.12.1",
 				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.12.1",
-				"@babel/plugin-proposal-numeric-separator": "^7.12.1",
+				"@babel/plugin-proposal-numeric-separator": "^7.12.7",
 				"@babel/plugin-proposal-object-rest-spread": "^7.12.1",
 				"@babel/plugin-proposal-optional-catch-binding": "^7.12.1",
-				"@babel/plugin-proposal-optional-chaining": "^7.12.1",
+				"@babel/plugin-proposal-optional-chaining": "^7.12.7",
 				"@babel/plugin-proposal-private-methods": "^7.12.1",
 				"@babel/plugin-proposal-unicode-property-regex": "^7.12.1",
 				"@babel/plugin-syntax-async-generators": "^7.8.0",
@@ -2522,7 +2954,7 @@
 				"@babel/plugin-transform-arrow-functions": "^7.12.1",
 				"@babel/plugin-transform-async-to-generator": "^7.12.1",
 				"@babel/plugin-transform-block-scoped-functions": "^7.12.1",
-				"@babel/plugin-transform-block-scoping": "^7.12.1",
+				"@babel/plugin-transform-block-scoping": "^7.12.11",
 				"@babel/plugin-transform-classes": "^7.12.1",
 				"@babel/plugin-transform-computed-properties": "^7.12.1",
 				"@babel/plugin-transform-destructuring": "^7.12.1",
@@ -2546,14 +2978,14 @@
 				"@babel/plugin-transform-reserved-words": "^7.12.1",
 				"@babel/plugin-transform-shorthand-properties": "^7.12.1",
 				"@babel/plugin-transform-spread": "^7.12.1",
-				"@babel/plugin-transform-sticky-regex": "^7.12.1",
+				"@babel/plugin-transform-sticky-regex": "^7.12.7",
 				"@babel/plugin-transform-template-literals": "^7.12.1",
-				"@babel/plugin-transform-typeof-symbol": "^7.12.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.12.10",
 				"@babel/plugin-transform-unicode-escapes": "^7.12.1",
 				"@babel/plugin-transform-unicode-regex": "^7.12.1",
 				"@babel/preset-modules": "^0.1.3",
-				"@babel/types": "^7.12.1",
-				"core-js-compat": "^3.6.2",
+				"@babel/types": "^7.12.11",
+				"core-js-compat": "^3.8.0",
 				"semver": "^5.5.0"
 			},
 			"dependencies": {
@@ -2566,13 +2998,19 @@
 						"@babel/types": "^7.12.5"
 					}
 				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
 				"@babel/types": {
-					"version": "7.12.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-					"integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
 					"dev": true,
 					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/helper-validator-identifier": "^7.12.11",
 						"lodash": "^4.17.19",
 						"to-fast-properties": "^2.0.0"
 					}
@@ -3024,9 +3462,9 @@
 			"dev": true
 		},
 		"@types/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-jJjHo1uOe+NENRIBvF46tJimUvPnmbQ41Ax0pEm7pRvhPg+wuj8VMOHHiMvaGmZRzRrCtm7KnL5OOE/6kHPK8w==",
+			"version": "16.14.2",
+			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.2.tgz",
+			"integrity": "sha512-BzzcAlyDxXl2nANlabtT4thtvbbnhee8hMmH/CcJrISDBVcJS1iOsP1f0OAgSdGE0MsY9tqcrb9YoZcOFv9dbQ==",
 			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
@@ -3034,12 +3472,12 @@
 			}
 		},
 		"@types/react-dom": {
-			"version": "16.9.9",
-			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.9.tgz",
-			"integrity": "sha512-jE16FNWO3Logq/Lf+yvEAjKzhpST/Eac8EMd1i4dgZdMczfgqC8EjpxwNgEe3SExHYLliabXDh9DEhhqnlXJhg==",
+			"version": "16.9.10",
+			"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.10.tgz",
+			"integrity": "sha512-ItatOrnXDMAYpv6G8UCk2VhbYVTjZT9aorLtA/OzDN9XJ2GKcfam68jutoAcILdRjsRUO8qb7AmyObF77Q8QFw==",
 			"dev": true,
 			"requires": {
-				"@types/react": "*"
+				"@types/react": "^16"
 			}
 		},
 		"@types/unist": {
@@ -3272,23 +3710,179 @@
 			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
-			"version": "4.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.19.0.tgz",
-			"integrity": "sha512-b/DQ17UGqWm5Z/c1j+wF8kW3Sqeg7e0CVFKeNd+uoI6wH+ruRsOcS7e0iutjQcwOLmvaZ3TYh48jjfkMBnLBqA==",
+			"version": "4.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-4.20.0.tgz",
+			"integrity": "sha512-VKPoC5We2GNxon5umOeZ7NIP4CfP7X5gqslSnNrLW4kD1XgmbVaCs2ISFF8+mObVVb6KAzbaUjI6OWljcUb5UA==",
 			"dev": true,
 			"requires": {
-				"@babel/core": "^7.11.6",
-				"@babel/plugin-transform-react-jsx": "^7.10.4",
-				"@babel/plugin-transform-runtime": "^7.11.5",
-				"@babel/preset-env": "^7.11.5",
-				"@babel/runtime": "^7.11.2",
+				"@babel/core": "^7.12.9",
+				"@babel/plugin-transform-react-jsx": "^7.12.7",
+				"@babel/plugin-transform-runtime": "^7.12.1",
+				"@babel/preset-env": "^7.12.7",
+				"@babel/runtime": "^7.12.5",
 				"@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
 				"@wordpress/browserslist-config": "^2.7.0",
-				"@wordpress/element": "^2.18.0",
+				"@wordpress/element": "^2.19.0",
 				"@wordpress/warning": "^1.3.0",
 				"core-js": "^3.6.4"
 			},
 			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/core": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+					"integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/generator": "^7.12.10",
+						"@babel/helper-module-transforms": "^7.12.1",
+						"@babel/helpers": "^7.12.5",
+						"@babel/parser": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.10",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"gensync": "^1.0.0-beta.1",
+						"json5": "^2.1.2",
+						"lodash": "^4.17.19",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+					"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/helper-module-imports": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+					"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.5"
+					}
+				},
+				"@babel/helper-module-transforms": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+					"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-module-imports": "^7.12.1",
+						"@babel/helper-replace-supers": "^7.12.1",
+						"@babel/helper-simple-access": "^7.12.1",
+						"@babel/helper-split-export-declaration": "^7.11.0",
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.1",
+						"@babel/types": "^7.12.1",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+					"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.12.7",
+						"@babel/helper-optimise-call-expression": "^7.12.10",
+						"@babel/traverse": "^7.12.10",
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-simple-access": {
+					"version": "7.12.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+					"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.1"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.12.5",
+					"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+					"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.10.4",
+						"@babel/traverse": "^7.12.5",
+						"@babel/types": "^7.12.5"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+					"dev": true
+				},
 				"@babel/runtime": {
 					"version": "7.12.5",
 					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
@@ -3296,6 +3890,132 @@
 					"dev": true,
 					"requires": {
 						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
 					}
 				}
 			}
@@ -3317,15 +4037,15 @@
 			}
 		},
 		"@wordpress/element": {
-			"version": "2.18.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.18.0.tgz",
-			"integrity": "sha512-aR1gOXFxIDcrLCSANe5PwOwYH40n29LzjqBascNkFo6f0LBekCZPbI3Bqq4EtoH/zjq2RKAO9PVPlQRDoQUlmA==",
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-2.19.0.tgz",
+			"integrity": "sha512-t6GnllujeJU2N7RagWvPSSki+VnIxUQktg+cDAFDWC4XHCVoZKgs/0B48yeZSvd9T/t4ry0aILh+zeEJ+5DuHg==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.11.2",
+				"@babel/runtime": "^7.12.5",
 				"@types/react": "^16.9.0",
 				"@types/react-dom": "^16.9.0",
-				"@wordpress/escape-html": "^1.10.0",
+				"@wordpress/escape-html": "^1.11.0",
 				"lodash": "^4.17.19",
 				"react": "^16.13.1",
 				"react-dom": "^16.13.1"
@@ -3349,12 +4069,12 @@
 			}
 		},
 		"@wordpress/escape-html": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.10.0.tgz",
-			"integrity": "sha512-peG+Ypnw8L3YiUWSe/3Nmyzlaoqqbn5JaBaLpL0o6pBxFvGwKr00fFJoi+Yq2yZ3LEFDrHBHlVYAB6A2aYIbew==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-1.11.0.tgz",
+			"integrity": "sha512-f/jk3SpYRUp04+LzdonNWBpH8jlm8RXGjK2TimfLz+wRFzFFdF7i2dI9GX+4gea/UuV+WtXAWkfARyV0HVDXwQ==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.11.2"
+				"@babel/runtime": "^7.12.5"
 			},
 			"dependencies": {
 				"@babel/runtime": {
@@ -3801,24 +4521,17 @@
 			}
 		},
 		"babel-loader": {
-			"version": "8.2.1",
-			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.1.tgz",
-			"integrity": "sha512-dMF8sb2KQ8kJl21GUjkW1HWmcsL39GOV5vnzjqrCzEPNY0S0UfMLnumidiwIajDSBmKhYf5iRW+HXaM4cvCKBw==",
+			"version": "8.2.2",
+			"resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.2.tgz",
+			"integrity": "sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==",
 			"dev": true,
 			"requires": {
-				"find-cache-dir": "^2.1.0",
+				"find-cache-dir": "^3.3.1",
 				"loader-utils": "^1.4.0",
-				"make-dir": "^2.1.0",
-				"pify": "^4.0.1",
+				"make-dir": "^3.1.0",
 				"schema-utils": "^2.6.5"
 			},
 			"dependencies": {
-				"emojis-list": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-					"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
-					"dev": true
-				},
 				"json5": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -3843,12 +4556,6 @@
 					"version": "1.2.5",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
 					"dev": true
 				}
 			}
@@ -4311,56 +5018,50 @@
 			}
 		},
 		"core-js": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.7.0.tgz",
-			"integrity": "sha512-NwS7fI5M5B85EwpWuIwJN4i/fbisQUwLwiSNUWeXlkAZ0sbBjLEvLvFLf1uzAUV66PcEPt4xCGCmOZSxVf3xzA==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.2.tgz",
+			"integrity": "sha512-FfApuSRgrR6G5s58casCBd9M2k+4ikuu4wbW6pJyYU7bd9zvFc9qf7vr5xmrZOhT9nn+8uwlH1oRR9jTnFoA3A==",
 			"dev": true
 		},
 		"core-js-compat": {
-			"version": "3.7.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.7.0.tgz",
-			"integrity": "sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==",
+			"version": "3.8.2",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.8.2.tgz",
+			"integrity": "sha512-LO8uL9lOIyRRrQmZxHZFl1RV+ZbcsAkFWTktn5SmH40WgLtSNYN4m4W2v9ONT147PxBY/XrRhrWq8TlvObyUjQ==",
 			"dev": true,
 			"requires": {
-				"browserslist": "^4.14.6",
+				"browserslist": "^4.16.0",
 				"semver": "7.0.0"
 			},
 			"dependencies": {
 				"browserslist": {
-					"version": "4.14.7",
-					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.7.tgz",
-					"integrity": "sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==",
+					"version": "4.16.1",
+					"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.1.tgz",
+					"integrity": "sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==",
 					"dev": true,
 					"requires": {
-						"caniuse-lite": "^1.0.30001157",
+						"caniuse-lite": "^1.0.30001173",
 						"colorette": "^1.2.1",
-						"electron-to-chromium": "^1.3.591",
+						"electron-to-chromium": "^1.3.634",
 						"escalade": "^3.1.1",
-						"node-releases": "^1.1.66"
+						"node-releases": "^1.1.69"
 					}
 				},
 				"caniuse-lite": {
-					"version": "1.0.30001159",
-					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-					"integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==",
+					"version": "1.0.30001173",
+					"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
+					"integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw==",
 					"dev": true
 				},
 				"electron-to-chromium": {
-					"version": "1.3.603",
-					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.603.tgz",
-					"integrity": "sha512-J8OHxOeJkoSLgBXfV9BHgKccgfLMHh+CoeRo6wJsi6m0k3otaxS/5vrHpMNSEYY4MISwewqanPOuhAtuE8riQQ==",
-					"dev": true
-				},
-				"escalade": {
-					"version": "3.1.1",
-					"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-					"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+					"version": "1.3.634",
+					"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.634.tgz",
+					"integrity": "sha512-QPrWNYeE/A0xRvl/QP3E0nkaEvYUvH3gM04ZWYtIa6QlSpEetRlRI1xvQ7hiMIySHHEV+mwDSX8Kj4YZY6ZQAw==",
 					"dev": true
 				},
 				"node-releases": {
-					"version": "1.1.67",
-					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.67.tgz",
-					"integrity": "sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==",
+					"version": "1.1.69",
+					"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.69.tgz",
+					"integrity": "sha512-DGIjo79VDEyAnRlfSqYTsy+yoHd2IOjJiKUozD2MV2D85Vso6Bug56mb9tT/fY5Urt0iqk01H7x+llAruDR2zA==",
 					"dev": true
 				},
 				"semver": {
@@ -5364,14 +6065,14 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
-			"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz",
+			"integrity": "sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==",
 			"dev": true,
 			"requires": {
 				"commondir": "^1.0.1",
-				"make-dir": "^2.0.0",
-				"pkg-dir": "^3.0.0"
+				"make-dir": "^3.0.2",
+				"pkg-dir": "^4.1.0"
 			}
 		},
 		"find-parent-dir": {
@@ -6314,25 +7015,18 @@
 			}
 		},
 		"make-dir": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
-			"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
 			"dev": true,
 			"requires": {
-				"pify": "^4.0.1",
-				"semver": "^5.6.0"
+				"semver": "^6.0.0"
 			},
 			"dependencies": {
-				"pify": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-					"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-					"dev": true
-				},
 				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -7093,48 +7787,12 @@
 			"dev": true
 		},
 		"pkg-dir": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
-			"integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+			"integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
 			"dev": true,
 			"requires": {
-				"find-up": "^3.0.0"
-			},
-			"dependencies": {
-				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-					"dev": true,
-					"requires": {
-						"locate-path": "^3.0.0"
-					}
-				},
-				"locate-path": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-					"dev": true,
-					"requires": {
-						"p-locate": "^3.0.0",
-						"path-exists": "^3.0.0"
-					}
-				},
-				"p-locate": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-					"dev": true,
-					"requires": {
-						"p-limit": "^2.0.0"
-					}
-				},
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
+				"find-up": "^4.0.0"
 			}
 		},
 		"plur": {
@@ -8556,14 +9214,6 @@
 				"@types/json-schema": "^7.0.5",
 				"ajv": "^6.12.4",
 				"ajv-keywords": "^3.5.2"
-			},
-			"dependencies": {
-				"ajv-keywords": {
-					"version": "3.5.2",
-					"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-					"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-					"dev": true
-				}
 			}
 		},
 		"semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,36 +20,75 @@
 			"dev": true
 		},
 		"@babel/core": {
-			"version": "7.11.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-			"integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+			"version": "7.12.10",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.10.tgz",
+			"integrity": "sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.10.4",
-				"@babel/generator": "^7.11.6",
-				"@babel/helper-module-transforms": "^7.11.0",
-				"@babel/helpers": "^7.10.4",
-				"@babel/parser": "^7.11.5",
-				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.11.5",
-				"@babel/types": "^7.11.5",
+				"@babel/generator": "^7.12.10",
+				"@babel/helper-module-transforms": "^7.12.1",
+				"@babel/helpers": "^7.12.5",
+				"@babel/parser": "^7.12.10",
+				"@babel/template": "^7.12.7",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.10",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
 				"lodash": "^4.17.19",
-				"resolve": "^1.3.2",
 				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"@babel/code-frame": {
-					"version": "7.10.4",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
-					"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
 					"dev": true,
 					"requires": {
 						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11"
 					}
 				},
 				"@babel/highlight": {
@@ -61,6 +100,59 @@
 						"@babel/helper-validator-identifier": "^7.10.4",
 						"chalk": "^2.0.0",
 						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
 					}
 				},
 				"ansi-styles": {
@@ -562,43 +654,268 @@
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-			"integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+			"version": "7.12.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.7.tgz",
+			"integrity": "sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.11.0"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-			"integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.10.4"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.11.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-			"integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-module-imports": "^7.10.4",
-				"@babel/helper-replace-supers": "^7.10.4",
-				"@babel/helper-simple-access": "^7.10.4",
-				"@babel/helper-split-export-declaration": "^7.11.0",
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.11.0",
-				"lodash": "^4.17.19"
+				"@babel/types": "^7.12.7"
 			},
 			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
 				"lodash": {
 					"version": "4.17.20",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
 					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
 					"dev": true
+				}
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
+			"integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.12.5"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+			"integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.1",
+				"@babel/helper-replace-supers": "^7.12.1",
+				"@babel/helper-simple-access": "^7.12.1",
+				"@babel/helper-split-export-declaration": "^7.11.0",
+				"@babel/helper-validator-identifier": "^7.10.4",
+				"@babel/template": "^7.10.4",
+				"@babel/traverse": "^7.12.1",
+				"@babel/types": "^7.12.1",
+				"lodash": "^4.17.19"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+					"dev": true
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					},
+					"dependencies": {
+						"@babel/helper-split-export-declaration": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+							"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+							"dev": true,
+							"requires": {
+								"@babel/types": "^7.12.11"
+							}
+						}
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
 				}
 			}
 		},
@@ -654,25 +971,233 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-			"integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+			"version": "7.12.11",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.11.tgz",
+			"integrity": "sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.10.4",
-				"@babel/helper-optimise-call-expression": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/helper-member-expression-to-functions": "^7.12.7",
+				"@babel/helper-optimise-call-expression": "^7.12.10",
+				"@babel/traverse": "^7.12.10",
+				"@babel/types": "^7.12.11"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.10.tgz",
+					"integrity": "sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+					"dev": true
+				},
+				"@babel/template": {
+					"version": "7.12.7",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+					"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.10.4",
+						"@babel/parser": "^7.12.7",
+						"@babel/types": "^7.12.7"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-			"integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+			"version": "7.12.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+			"integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
 			"dev": true,
 			"requires": {
-				"@babel/template": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/types": "^7.12.1"
+			},
+			"dependencies": {
+				"@babel/helper-validator-identifier": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+					"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+					"dev": true
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/helper-skip-transparent-expression-wrappers": {
@@ -743,14 +1268,193 @@
 			}
 		},
 		"@babel/helpers": {
-			"version": "7.10.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-			"integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.5.tgz",
+			"integrity": "sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==",
 			"dev": true,
 			"requires": {
 				"@babel/template": "^7.10.4",
-				"@babel/traverse": "^7.10.4",
-				"@babel/types": "^7.10.4"
+				"@babel/traverse": "^7.12.5",
+				"@babel/types": "^7.12.5"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+					"integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "^7.10.4"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.11.tgz",
+					"integrity": "sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11",
+						"jsesc": "^2.5.1",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.11.tgz",
+					"integrity": "sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.12.10",
+						"@babel/template": "^7.12.7",
+						"@babel/types": "^7.12.11"
+					},
+					"dependencies": {
+						"@babel/template": {
+							"version": "7.12.7",
+							"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.7.tgz",
+							"integrity": "sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==",
+							"dev": true,
+							"requires": {
+								"@babel/code-frame": "^7.10.4",
+								"@babel/parser": "^7.12.7",
+								"@babel/types": "^7.12.7"
+							}
+						}
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.12.10",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.10.tgz",
+					"integrity": "sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.10"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.11.tgz",
+					"integrity": "sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==",
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.12.11"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.10.4",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+					"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.4",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.12.11",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.11.tgz",
+					"integrity": "sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==",
+					"dev": true
+				},
+				"@babel/traverse": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.12.tgz",
+					"integrity": "sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==",
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.12.11",
+						"@babel/generator": "^7.12.11",
+						"@babel/helper-function-name": "^7.12.11",
+						"@babel/helper-split-export-declaration": "^7.12.11",
+						"@babel/parser": "^7.12.11",
+						"@babel/types": "^7.12.12",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.19"
+					}
+				},
+				"@babel/types": {
+					"version": "7.12.12",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
+					"integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
+					"dev": true,
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.12.11",
+						"lodash": "^4.17.19",
+						"to-fast-properties": "^2.0.0"
+					},
+					"dependencies": {
+						"@babel/helper-validator-identifier": {
+							"version": "7.12.11",
+							"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+							"integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+							"dev": true
+						}
+					}
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"lodash": {
+					"version": "4.17.20",
+					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+					"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+					"dev": true
+				},
+				"source-map": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+					"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
 			}
 		},
 		"@babel/highlight": {
@@ -3043,9 +3747,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.12.5",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.5.tgz",
+			"integrity": "sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
 		"url": "https://github.com/washingtonstateuniversity/hrs.wsu.edu/issues"
 	},
 	"devDependencies": {
-		"@wordpress/babel-preset-default": "^4.19.0",
+		"@wordpress/babel-preset-default": "^4.20.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",
 		"@wordpress/eslint-plugin": "^7.3.0",
 		"@wordpress/npm-package-json-lint-config": "^3.1.0",
-		"babel-loader": "^8.2.1",
+		"babel-loader": "^8.2.2",
 		"copy-webpack-plugin": "^7.0.0",
 		"cssnano": "^4.1.10",
 		"eslint": "^7.13.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
 		"url": "https://github.com/washingtonstateuniversity/hrs.wsu.edu/issues"
 	},
 	"devDependencies": {
+		"@babel/core": "^7.12.10",
+		"@babel/runtime": "^7.12.5",
 		"@wordpress/babel-preset-default": "^4.20.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "^2.9.0",
 		"@wordpress/eslint-plugin": "^7.3.0",


### PR DESCRIPTION
## Description

Update Babel Loader and WP Babel Preset to latest versions. Add Babel Core and Babel Runtime, which are now required to be installed along with Babel Loader.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
