### PR TITLE
Fix ESLint issues

### DIFF
--- a/src/components/search-menu/index.js
+++ b/src/components/search-menu/index.js
@@ -94,8 +94,11 @@ class SearchMenu {
 
 	_addEventListeners() {
 		this._trigger.addEventListener( 'click', this.toggle );
-		document.addEventListener( 'click', this.handleSelectOutside );
-		document.addEventListener( 'keyup', ( event ) => {
+		this._trigger.ownerDocument.addEventListener(
+			'click',
+			this.handleSelectOutside
+		);
+		this._trigger.ownerDocument.addEventListener( 'keyup', ( event ) => {
 			if ( this._isExpanded( this._trigger ) ) {
 				if ( 'Escape' === event.key || 'Esc' === event.key ) {
 					this.collapse( this._trigger, this._searchMenu );


### PR DESCRIPTION
## Description

Avoid using (add|remove)EventListener with globals. Prefer `ownerDocument` instead of global for event listeners.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
