### PR TITLE
Enhancement/search block 5.7 compat

### DIFF
--- a/src/components/editor.css
+++ b/src/components/editor.css
@@ -7,6 +7,7 @@
 @import "./preformatted/editor.css";
 @import "./pullquote/editor.css";
 @import "./quote/editor.css";
+@import "./search/editor.css";
 @import "./list/editor.css";
 @import "./navigation-link/editor.css";
 @import "./separator/editor.css";

--- a/src/components/search/editor.css
+++ b/src/components/search/editor.css
@@ -1,0 +1,82 @@
+.wp-block-search {
+
+	/* stylelint-disable selector-class-pattern */
+	& .wp-block-search__inside-wrapper {
+		border: none;
+		display: flex;
+	}
+
+	& .wp-block-search__inside-wrapper .wp-block-search__input,
+	& .wp-block-search__inside-wrapper .wp-block-search__button {
+		font-size: var(--font-size-2);
+		line-height: 1.5;
+		margin: 0;
+		padding: 20px;
+		width: 100%;
+	}
+
+	& .wp-block-search__inside-wrapper .wp-block-search__input {
+		background: #f8f8f8;
+		border: 1px solid #ccc;
+		border-top-left-radius: 5px;
+		border-bottom-left-radius: 5px;
+		box-shadow: 0 0 0 0 rgba(0, 0, 0, 0.03), 0 0 0 0 rgba(0, 0, 0, 0.03), 0 0 0 0 rgba(0, 0, 0, 0.02);
+		color: var(--text-color);
+		transition: box-shadow 0.3s cubic-bezier(0, 0, 0.03, 1);
+
+		&:focus {
+			border-color: #999;
+			box-shadow: 0 8px 10px 1px rgba(0, 0, 0, 0.03), 0 3px 14px 2px rgba(0, 0, 0, 0.03), 0 4px 15px 0 rgba(0, 0, 0, 0.02);
+			outline: none;
+		}
+	}
+
+	/* Highly selected to override WP core styles. */
+	& .wp-block-search__inside-wrapper .wp-block-search__button.wp-block-search__button {
+		word-wrap: break-word;
+		background: var(--brand-crimson);
+		border: none;
+		border-top-right-radius: 5px;
+		border-bottom-right-radius: 5px;
+		box-shadow: 0 2px 2px 0 rgba(0, 0, 0, 0.16), 0 0 0 1px rgba(0, 0, 0, 0.1);
+		color: #fff;
+		cursor: pointer;
+		display: inline-block;
+		flex-shrink: 1;
+		font-family: inherit;
+		font-size: var(--font-size-base);
+		letter-spacing: 0.85px;
+		line-height: 2.5;
+		outline-offset: -2px;
+		padding: 0.75rem 1.5rem;
+		text-align: center;
+		text-decoration: none;
+		text-transform: uppercase;
+		transition: all 0.3s ease;
+		width: auto;
+
+		&.has-icon {
+			line-height: 0;
+		}
+	}
+
+	& .wp-block-search__button svg {
+		height: 36px;
+		width: 36px;
+	}
+
+	/* We don't use the button inside/outside style. */
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper {
+		border: 0;
+		padding: 0;
+	}
+
+	&.wp-block-search__button-inside .wp-block-search__inside-wrapper .wp-block-search__input {
+		border: 1px solid #ccc;
+		border-top-left-radius: 5px;
+		border-bottom-left-radius: 5px;
+		padding: 20px;
+	}
+	/* stylelint-enable selector-class-pattern */
+
+}

--- a/src/components/search/style.css
+++ b/src/components/search/style.css
@@ -46,11 +46,29 @@
 		flex-shrink: 1;
 		width: auto;
 	}
-	/* stylelint-enable selector-class-pattern */
+
 }
 
-.wp-block-search label {
-	align-self: center;
-	font-size: var(--font-size-2);
-	margin-right: 1rem;
+.wp-block-search {
+
+	& label {
+		font-size: var(--font-size-2);
+	}
+
+	& .wp-block-search__button.has-icon {
+		line-height: 0;
+
+		&:hover .search-icon,
+		&:focus .search-icon {
+			fill: var(--nav-color-hover);
+		}
+	}
+
+	& .search-icon {
+		height: 36px;
+		fill: #fff;
+		width: 36px;
+	}
+	/* stylelint-enable selector-class-pattern */
+
 }

--- a/src/components/search/style.css
+++ b/src/components/search/style.css
@@ -1,8 +1,15 @@
+.search-form {
+	display: flex;
+}
+
 .search-form,
 .wp-block-search {
-	display: flex;
 	margin-top: 1.5rem;
 	margin-bottom: 1.5rem;
+
+	& .wp-block-search__inside-wrapper {
+		display: flex;
+	}
 
 	& input {
 		border: 1px solid #ccc;
@@ -28,7 +35,8 @@
 		outline-offset: -2px;
 	}
 
-	& [type="submit"] {
+	& .search-submit,
+	& .wp-block-search__button {
 		border: none;
 		border-top-right-radius: 5px;
 		border-top-left-radius: 0;

--- a/src/components/search/style.css
+++ b/src/components/search/style.css
@@ -7,6 +7,7 @@
 	margin-top: 1.5rem;
 	margin-bottom: 1.5rem;
 
+	/* stylelint-disable selector-class-pattern */
 	& .wp-block-search__inside-wrapper {
 		display: flex;
 	}
@@ -45,6 +46,7 @@
 		flex-shrink: 1;
 		width: auto;
 	}
+	/* stylelint-enable selector-class-pattern */
 }
 
 .wp-block-search label {


### PR DESCRIPTION
## Description

Update search block styles to support layout options added in WP 5.7.

## How has this been tested?

Works as expected in local environment.

## Checklist:

- [x] My code is tested.
- [x] My code follows the WordPress code style. <!-- Check code: `npm run test` -->
- [x] My code follows the accessibility standards. <!-- Guidelines: -->
- [x] My code has proper inline documentation. <!-- Guidelines: -->
- [x] I've included developer documentation if appropriate.
